### PR TITLE
Bump `stdlib` Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: aiken-lang/setup-aiken@v1.0.3
         with:
           version: v1.1.9
       - run: aiken fmt --check
-      - run: aiken check -D
+      - run: aiken check
       - run: aiken docs -o docs
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: "docs/"
 
@@ -45,4 +45,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aiken-lang/setup-aiken@v1.0.2
+      - uses: aiken-lang/setup-aiken@v1.0.3
         with:
           version: v1.1.9
       - run: aiken fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
           version: v1.1.7
       - run: aiken fmt --check
       - run: aiken check -D
-      - run: aiken build
       - run: aiken docs -o docs
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aiken-lang/setup-aiken@v1.0.2
+      - uses: aiken-lang/setup-aiken@v1
         with:
           version: v1.1.9
       - run: aiken fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - uses: aiken-lang/setup-aiken@v1.0.3
         with:
           version: v1.1.9
       - run: aiken fmt --check
       - run: aiken check -D
       - run: aiken docs -o docs
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: "docs/"
 
@@ -45,4 +45,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           version: v1.1.9
       - run: aiken fmt --check
+      - run: aiken check -D
       - run: aiken docs -o docs
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: aiken-lang/setup-aiken@v1.0.2
         with:
-          version: v1.1.7
+          version: v1.1.9
       - run: aiken fmt --check
       - run: aiken check -D
       - run: aiken docs -o docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           version: v1.1.9
       - run: aiken fmt --check
-      - run: aiken check -D
       - run: aiken docs -o docs
       - uses: actions/upload-pages-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - run: aiken check -D
       - run: aiken build
       - run: aiken docs -o docs
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: "docs/"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: aiken-lang/setup-aiken@v1
+      - uses: aiken-lang/setup-aiken@v1.0.2
         with:
           version: v1.1.9
       - run: aiken fmt --check
@@ -45,4 +45,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+docs

--- a/aiken.lock
+++ b/aiken.lock
@@ -3,12 +3,12 @@
 
 [[requirements]]
 name = "aiken-lang/stdlib"
-version = "v2.2.0"
+version = "v3.0.0"
 source = "github"
 
 [[packages]]
 name = "aiken-lang/stdlib"
-version = "v2.2.0"
+version = "v3.0.0"
 requirements = []
 source = "github"
 

--- a/aiken.lock
+++ b/aiken.lock
@@ -2,14 +2,15 @@
 # You typically do not need to edit this file
 
 [[requirements]]
-name = "aiken-lang/stdlib"
-version = "v3.0.0"
+name = "keyan-m/stdlib"
+version = "remove-qualifier"
 source = "github"
 
 [[packages]]
-name = "aiken-lang/stdlib"
-version = "v3.0.0"
+name = "keyan-m/stdlib"
+version = "remove-qualifier"
 requirements = []
 source = "github"
 
 [etags]
+"keyan-m/stdlib@remove-qualifier" = [{ secs_since_epoch = 1764865423, nanos_since_epoch = 457678324 }, "2440586c5df7e42075f5b2ec4b66672c53f03187663c0644cf60fb3ff1c4c239"]

--- a/aiken.toml
+++ b/aiken.toml
@@ -11,8 +11,8 @@ project = "aiken-scott-utils"
 platform = "github"
 
 [[dependencies]]
-name = "aiken-lang/stdlib"
-version = "v3.0.0"
+name = "keyan-m/stdlib"
+version = "remove-qualifier"
 source = "github"
 
 [config]

--- a/aiken.toml
+++ b/aiken.toml
@@ -1,5 +1,6 @@
 name = "keyan-m/aiken-scott-utils"
 version = "1.4.0"
+compiler = "v1.1.19"
 plutus = "v3"
 license = "Apache-2.0"
 description = "A set of utility functions that return multiple values in Scott encoding rather than tuples of 2 or higher"

--- a/aiken.toml
+++ b/aiken.toml
@@ -1,5 +1,5 @@
 name = "keyan-m/aiken-scott-utils"
-version = "1.3.0"
+version = "1.4.0"
 plutus = "v3"
 license = "Apache-2.0"
 description = "A set of utility functions that return multiple values in Scott encoding rather than tuples of 2 or higher"
@@ -11,7 +11,7 @@ platform = "github"
 
 [[dependencies]]
 name = "aiken-lang/stdlib"
-version = "v2.2.0"
+version = "v3.0.0"
 source = "github"
 
 [config]

--- a/lib/aiken-scott-utils/list.ak
+++ b/lib/aiken-scott-utils/list.ak
@@ -4,38 +4,43 @@
 //// Sample code to see how you can use one of the fold functions with the
 //// backpassing syntax:
 //// ```aiken
+//// use aiken/math.{pow}
 //// use aiken_scott_utils/list as scott_list
 ////
-//// fn avg_of_sums_and_products(xs: List<Int>) -> Int {
+//// fn avg_of_sums_products_powers(xs: List<Int>) -> Int {
 ////   let
 ////     sum,
 ////     product,
+////     power
 ////   <-
-////     scott_list.foldr2(
+////     scott_list.foldr3(
 ////       xs,
 ////       0,
 ////       1,
-////       fn(x, sum_so_far, prod_so_far, return) {
-////         return(sum_so_far + x, prod_so_far * x)
+////       1,
+////       fn(x, sum_so_far, prod_so_far, pow_so_far, return) {
+////         return(sum_so_far + x, prod_so_far * x, pow(pow_so_far, x))
 ////       },
 ////     ) 
-////   (sum + product) / 2
+////   (sum + product + power) / 3
 //// }
 //// ```
 ////
 //// The same code without backpassing syntactic sugar:
 //// ```aiken
+//// use aiken/math.{pow}
 //// use aiken_scott_utils/list as scott_list
 ////
 //// fn avg_of_sums_and_products_desugared(xs: List<Int>) -> Int {
-////   scott_list.foldr2(
+////   scott_list.foldr3(
 ////     xs,
 ////     0,
 ////     1,
-////     fn(x, sum_so_far, prod_so_far, return) {
-////       return(sum_so_far + x, prod_so_far * x)
+////     1,
+////     fn(x, sum_so_far, prod_so_far, pow_so_far, return) {
+////       return(sum_so_far + x, prod_so_far * x, pow(pow_so_far, x))
 ////     },
-////     fn(sum, product) { (sum + product) / 2 }
+////     fn(sum, product, power) { (sum + product + power) / 3 }
 ////   ) 
 //// }
 //// ```
@@ -44,17 +49,6 @@ use aiken/collection/list
 use aiken_scott_utils/types.{Scott2, Scott3, Scott4, Scott5, Scott6}
 
 // --- FOLDS -------------------------------------------------------------------
-
-fn do_foldr2(
-  self: List<x>,
-  with: fn(x, a, b, Scott2<a, b, result>) -> result,
-  return: Scott2<a, b, result>,
-) -> Scott2<a, b, result> {
-  when self is {
-    [] -> return
-    [x, ..xs] -> do_foldr2(xs, with, fn(a, b) { with(x, a, b, return) })
-  }
-}
 
 fn do_foldr3(
   self: List<x>,
@@ -105,32 +99,6 @@ fn do_foldr6(
         fn(a, b, c, d, e, f) { with(x, a, b, c, d, e, f, return) },
       )
   }
-}
-
-pub fn foldl2(
-  self: List<x>,
-  zero_a: a,
-  zero_b: b,
-  with: fn(x, a, b, Scott2<a, b, result>) -> result,
-  return: Scott2<a, b, result>,
-) -> result {
-  when self is {
-    [] -> return(zero_a, zero_b)
-    [x, ..xs] -> {
-      let acc_a, acc_b <- with(x, zero_a, zero_b)
-      foldl2(xs, acc_a, acc_b, with, return)
-    }
-  }
-}
-
-pub fn foldr2(
-  self: List<x>,
-  zero_a: a,
-  zero_b: b,
-  with: fn(x, a, b, Scott2<a, b, result>) -> result,
-  return: Scott2<a, b, result>,
-) -> result {
-  do_foldr2(self, with, return)(zero_a, zero_b)
 }
 
 pub fn foldl3(

--- a/lib/aiken-scott-utils/list.ak
+++ b/lib/aiken-scott-utils/list.ak
@@ -19,7 +19,7 @@
 ////       1,
 ////       1,
 ////       fn(x, sum_so_far, prod_so_far, pow_so_far, return) {
-////         return(sum_so_far + x, prod_so_far * x, pow(pow_so_far, x))
+////         return(sum_so_far + x, prod_so_far * x, pow(x, pow_so_far))
 ////       },
 ////     ) 
 ////   (sum + product + power) / 3
@@ -38,7 +38,7 @@
 ////     1,
 ////     1,
 ////     fn(x, sum_so_far, prod_so_far, pow_so_far, return) {
-////       return(sum_so_far + x, prod_so_far * x, pow(pow_so_far, x))
+////       return(sum_so_far + x, prod_so_far * x, pow(x, pow_so_far))
 ////     },
 ////     fn(sum, product, power) { (sum + product + power) / 3 }
 ////   ) 

--- a/lib/aiken-scott-utils/tests.ak
+++ b/lib/aiken-scott-utils/tests.ak
@@ -23,7 +23,7 @@ test foldr2() {
     _,
     acc1,
   <-
-    scott_list.foldr2(
+    list.foldr2(
       fold_elems,
       0,
       1,
@@ -37,7 +37,7 @@ test foldl2() {
     _,
     acc1,
   <-
-    scott_list.foldl2(
+    list.foldl2(
       fold_elems,
       0,
       1,

--- a/plutus.json
+++ b/plutus.json
@@ -1,0 +1,14 @@
+{
+  "preamble": {
+    "title": "keyan-m/aiken-scott-utils",
+    "description": "A set of utility functions that return multiple values in Scott encoding rather than tuples of 2 or higher",
+    "version": "1.4.0",
+    "plutusVersion": "v3",
+    "compiler": {
+      "name": "Aiken",
+      "version": "v1.1.19+e525483"
+    },
+    "license": "Apache-2.0"
+  },
+  "validators": []
+}


### PR DESCRIPTION
Removes implementations of `foldr2` and `foldl2` as they are now part of `stdlib`.